### PR TITLE
Clear out environment vars like PKG_CONFIG_PATH, LD_LIBRARY_PATH etc.

### DIFF
--- a/bin/junest
+++ b/bin/junest
@@ -23,6 +23,17 @@ JUNEST_BASE="$(dirname $0)/.."
 source "${JUNEST_BASE}/lib/core.sh"
 
 ###################################
+### Prep environment            ###
+###################################
+
+# clear out environment variables that may affect builds done within
+# the Arch chroot; for example AUR builds with yaourt
+
+unset PKG_CONFIG_PATH LD_LIBRARY_PATH C_INCLUDE_PATH \
+      MODULEBUILDRC MODULEPATH MODULESHOME \
+      PERL_MM_OPT PERL5LIB
+
+###################################
 ### General functions           ###
 ###################################
 


### PR DESCRIPTION
These variables can break builds attempted within the chroot.

Example where this problem arises:

On my system I have various libraries the sysadmin has installed into `/usr/pkg/lib` that programs I have compiled outside of JuNest link against.  So I have those in PKG_CONFIG_PATH.  But then I found things I build inside JuNest got linked to libraries like libselinux.so which should never happen with Arch!  My solution was to manually unset all these variables before firing up JuNest.