### PR TITLE
Allow to configure additional packages installed to the minimal junest image

### DIFF
--- a/bin/junest
+++ b/bin/junest
@@ -130,7 +130,7 @@ check_cli(){
     fi
     if [ "$ARGS" != "" ]
     then
-        if $OPT_BUILD_IMAGE || $OPT_DELETE || $OPT_HELP || $OPT_SETUP_FROM_FILE || \
+        if $OPT_DELETE || $OPT_HELP || $OPT_SETUP_FROM_FILE || \
             $OPT_VERSION || $OPT_DISABLE_VALIDATION || $OPT_CHECK
         then
             die "No arguments are needed. For the CLI syntax run: $CMD --help"
@@ -191,7 +191,7 @@ function execute_operation(){
 	$OPT_VERSION && version && return
 
 	if $OPT_BUILD_IMAGE; then
-		build_image_env $OPT_DISABLE_VALIDATION $OPT_SKIP_ROOT_TEST
+		build_image_env $OPT_DISABLE_VALIDATION $OPT_SKIP_ROOT_TEST $ARGS
 		return
 	elif $OPT_DELETE; then
 		delete_env

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -393,23 +393,15 @@ function build_image_env(){
     _install_from_aur ${maindir} "${CMD}-git" "${CMD}.install"
     sudo pacman --noconfirm --root ${maindir}/root -Rsn git
 
+    info "Setting up the pacman keyring (this might take a while!)..."
+    sudo arch-chroot ${maindir}/root bash -c "pacman-key --init; pacman-key --populate archlinux"
+
     local extra
     for extra in $extra_packages
     do
         info "Installing $extra additional package..."
-        if package-query -Sq $extra
-        then
-            sudo pacman --noconfirm --root ${maindir}/root -S $extra
-        elif package-query -Aq $extra
-        then
-            _install_from_aur ${maindir} $extra
-        else
-            info "...package not found - skipping"
-        fi
+        yaourt --root ${maindir}/root -A --noconfirm -S ${extra}
     done
-
-    info "Setting up the pacman keyring (this might take a while!)..."
-    sudo arch-chroot ${maindir}/root bash -c "pacman-key --init; pacman-key --populate archlinux"
 
     sudo rm ${maindir}/root/var/cache/pacman/pkg/*
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -309,7 +309,7 @@ function _install_from_aur(){
     builtin cd ${maindir}/packages/${pkgname}
     $CURL "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=${pkgname}"
     [ -z "${installname}" ] || $CURL "https://aur.archlinux.org/cgit/aur.git/plain/${installname}?h=${pkgname}"
-    makepkg -sfc
+    makepkg -sfc --noconfirm
     sudo pacman --noconfirm --root ${maindir}/root -U ${pkgname}*.pkg.tar.xz
 }
 


### PR DESCRIPTION
Now you can pass the list of packages (groups) to junest build:

```
junest -b base-devel 0verkill-git
```

It should support both official distribution and AUR