### PR TITLE
Issue #127: Do not let proot mount the mtab file

### DIFF
--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -263,7 +263,7 @@ function test_run_env_as_proot_mtab(){
     $(run_env_as_fakeroot "-k 3.10" "echo")
     assertTrue "[ -e $JUNEST_HOME/etc/mtab ]"
     $(run_env_as_user "-k 3.10" "echo")
-    assertTrue "[ ! -e $JUNEST_HOME/etc/mtab ]"
+    assertTrue "[ -e $JUNEST_HOME/etc/mtab ]"
 }
 
 function test_run_env_as_root_mtab(){


### PR DESCRIPTION
This change prevents inconsistency problems when the JuNest environment
is run simultaneously in fakeroot and normal user. The mtab file is
never mount by proot but, instead, it is symlinked to /proc/self/mounts.