### PR TITLE
:bug: :racehorse: fix concurrency in init code, fixes #163

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -420,15 +420,19 @@ function _provide_bindings_as_user(){
 #  None
 #######################################
 function _build_passwd_and_group(){
-    if ! getent_cmd passwd > ${JUNEST_HOME}/etc/junest/passwd
-    then
-        warn "getent command failed or does not exist. Binding directly from /etc/passwd."
-        cp_cmd /etc/passwd ${JUNEST_HOME}/etc/junest/passwd
+    if [ ! -f ${JUNEST_HOME}/etc/junest/passwd ] ; then
+        if ! getent_cmd passwd > ${JUNEST_HOME}/etc/junest/passwd
+        then
+            warn "getent command failed or does not exist. Binding directly from /etc/passwd."
+            cp_cmd /etc/passwd ${JUNEST_HOME}/etc/junest/passwd
+        fi
     fi
-    if ! getent_cmd group > ${JUNEST_HOME}/etc/junest/group
-    then
-        warn "getent command failed or does not exist. Binding directly from /etc/group."
-        cp_cmd /etc/group ${JUNEST_HOME}/etc/junest/group
+    if [ ! -f ${JUNEST_HOME}/etc/junest/group ] ; then
+        if ! getent_cmd group > ${JUNEST_HOME}/etc/junest/group
+        then
+            warn "getent command failed or does not exist. Binding directly from /etc/group."
+            cp_cmd /etc/group ${JUNEST_HOME}/etc/junest/group
+        fi
     fi
 }
 


### PR DESCRIPTION
Caches and prefers existing .junest/etc/passwd and group files

Before this fix it was possible that concurrent startup (as in multiple junest processes) lead to partial files for some of the junest processes.

This is a quick fix removing the bug and speeding up startup. There are however a couple of issues that more experienced junest members should look into:
- [ ] are there other shared files that could cause concurrency issues between multiple junest invocations? I didn't find any, but please check.
- [ ] caching always comes at the cost of outdated info... in theory it is possible that the system's `passwd` and `group` info change. This will however not happen on each normal junest user startup, which is the rational for my fix. It might however be desirable to allow a user to manually reset such caches. Docs should point out that such calls shouldn't be parallelized though.
