### PR TITLE
Update README.md to include separately maintained junest build image

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Firstly, you will need to have git-lfs installed on your system and in your PATH
 This would be the instructions for you to install junest (which are also in Filippo's documentation) using my custom built junest build image:
 
 ```
+## Make sure that git-lfs is initialised
+[guest@pc ~]$ git lfs install
+
 ## Downloading Junest
 $ git clone git://github.com/fsquillace/junest ~/.local/share/junest ## Downloads junest in your local system
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ section below.
 ## Method ##
 Install junest using the latest junest build image maintained in [srgk26/junest_build_image](https://github.com/srgk26/junest_build_image) repo.
 
-Firstly, you will need to have git-lfs installed on your system. This is necessary to be able to download the junest build images uploaded to this GitHub repo using git-lfs. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be sudo pacman -S git-lfs.
+Firstly, you will need to have git-lfs installed on your system. This is necessary to be able to download the junest build images uploaded to this GitHub repo using git-lfs. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be `sudo pacman -S git-lfs`.
 
 This would be the instructions for you to install junest (which are also in Filippo's documentation) using my custom built junest build image:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ section below.
 ## Method ##
 Install junest using the latest junest build image maintained in [srgk26/junest_build_image](https://github.com/srgk26/junest_build_image) repo.
 
-Firstly, you will need to have git-lfs installed on your system. This is necessary to be able to download the junest build images uploaded to this GitHub repo using `git-lfs`. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be `sudo pacman -S git-lfs`.
+Firstly, you will need to have git-lfs installed on your system and in your PATH. This is necessary to be able to download the junest build images uploaded to this GitHub repo using `git-lfs`. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be `sudo pacman -S git-lfs`.
 
 This would be the instructions for you to install junest (which are also in Filippo's documentation) using my custom built junest build image:
 

--- a/README.md
+++ b/README.md
@@ -99,17 +99,21 @@ crash. For further information, read the [Troubleshooting](#troubleshooting)
 section below.
 
 ## Method ##
-Install junest using the latest junest build image maintained in [srgk26/junest_build_image](https://github.com/srgk26/junest_build_image) repo:
+Install junest using the latest junest build image maintained in [srgk26/junest_build_image](https://github.com/srgk26/junest_build_image) repo.
+
+Firstly, you will need to have git-lfs installed on your system. This is necessary to be able to download the junest build images uploaded to this GitHub repo using git-lfs. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be sudo pacman -S git-lfs.
+
+This would be the instructions for you to install junest (which are also in Filippo's documentation) using my custom built junest build image:
 
 ```
 ## Downloading Junest
 $ git clone git://github.com/fsquillace/junest ~/.local/share/junest ## Downloads junest in your local system
 
-## Add this line to ~/.bashrc configuration to add junest to PATH
-$ vim ~/.bashrc
+## Add this line to ~/.bash_profile configuration to add junest to PATH
+$ vim ~/.bash_profile
 export PATH=~/.local/share/junest/bin:$PATH ## Adds junest to PATH
 
-$ source ~/.bashrc
+$ source ~/.bash_profile
 
 ## Downloading the latest junest system build image from this repo
 $ git clone https://github.com/srgk26/junest_build_image.git ## Clone repo

--- a/README.md
+++ b/README.md
@@ -98,26 +98,27 @@ and 64 bit) and ARM architectures. It is still possible to run JuNest on lower
 crash. For further information, read the [Troubleshooting](#troubleshooting)
 section below.
 
+## Method ##
+Install junest using the latest junest build image maintained in [srgk26/junest_build_image](https://github.com/srgk26/junest_build_image) repo:
 
-## Method one (Recommended) ##
-Just clone the JuNest repo somewhere (for example in ~/.local/share/junest):
+```
+## Downloading Junest
+$ git clone git://github.com/fsquillace/junest ~/.local/share/junest ## Downloads junest in your local system
 
-    git clone git://github.com/fsquillace/junest ~/.local/share/junest
-    export PATH=~/.local/share/junest/bin:$PATH
+## Add this line to ~/.bashrc configuration to add junest to PATH
+$ vim ~/.bashrc
+export PATH=~/.local/share/junest/bin:$PATH ## Adds junest to PATH
 
-### Installation using AUR (Arch Linux only) ###
-If you are using an Arch Linux system you can, alternatively, install JuNest from the [AUR repository](https://aur.archlinux.org/):
+$ source ~/.bashrc
 
-    yaourt -S junest-git
-    export PATH=/opt/junest/bin:$PATH
+## Downloading the latest junest system build image from this repo
+$ git clone https://github.com/srgk26/junest_build_image.git ## Clone repo
+$ cd junest_build_image/build_images ## Move into the directory containing junest build images
 
-## Method two ##
-Alternatively, another installation method would be to directly download the JuNest image and place it to the default directory ~/.junest:
-
-    ARCH=<one of "x86_64", "x86", "arm">
-    mkdir ~/.junest
-    curl https://s3-eu-west-1.amazonaws.com/junest-repo/junest/junest-${ARCH}.tar.gz | tar -xz -C ~/.junest
-    export PATH=~/.junest/opt/junest/bin:$PATH
+## Installing Junest
+$ junest -i junest-[date]-x86_64.tar.gz ## Replace date with the latest date available; This junest-[date]-x86_64.tar.gz is the custom junest system image from this repository.
+$ cd ~ && rm -rf junest_build_image ## Delete this repo git clone from your system
+```
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ section below.
 ## Method ##
 Install junest using the latest junest build image maintained in [srgk26/junest_build_image](https://github.com/srgk26/junest_build_image) repo.
 
-Firstly, you will need to have git-lfs installed on your system. This is necessary to be able to download the junest build images uploaded to this GitHub repo using git-lfs. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be `sudo pacman -S git-lfs`.
+Firstly, you will need to have git-lfs installed on your system. This is necessary to be able to download the junest build images uploaded to this GitHub repo using `git-lfs`. Download it from https://git-lfs.github.com/, or use your package manager (if you have permission). For Arch Linux, this would be `sudo pacman -S git-lfs`.
 
 This would be the instructions for you to install junest (which are also in Filippo's documentation) using my custom built junest build image:
 


### PR DESCRIPTION
Hi!

Recently, I noticed that the default build system provided in your URL seems outdated, in that it gives problems installing packages like vim. This problem was also raised in an issue #219. The problem is rectified when I build my own image using your instructions. I then created my own repo, uploading my own latest system build image so I could use it as needed. I will also be maintaining this repo from time to time.

I thought of somehow possibly including this in your project too, so new users without an existing Arch Linux system (therefore can't build their own system image), or simply to avoid the pain of building one themselves, can now use the images maintained in my repo.

I have updated your README to include this. I have also deleted the section using yaourt to install since yaourt is no longer in use in Arch Linux.

If you are happy with this change, or edit as you see fit, kindly accept the proposed changes.