### PR TITLE
🎨 Tidy sudo-fake PKGBUILD

### DIFF
--- a/pkgs/sudo-fake/PKGBUILD
+++ b/pkgs/sudo-fake/PKGBUILD
@@ -1,45 +1,20 @@
 # Maintainer: Filippo Squillace <feel dot sqoox at gmail dot com>
-# More details on how to change this file:
-# https://wiki.archlinux.org/index.php/PKGBUILD
-# https://wiki.archlinux.org/index.php/Creating_packages
-# https://wiki.archlinux.org/index.php/Arch_User_Repository#Submitting_packages
 
 pkgname=sudo-fake
 pkgver=0.1.0
 pkgrel=1
 pkgdesc="Simple script that bypasses sudo and execute the actual command. Useful for fakeroot environments."
-arch=('any')
-url=""
-license=('GPL')
-groups=()
-depends=('fakeroot' 'fakechroot')
-makedepends=()
-provides=('sudo')
-conflicts=('sudo')
-backup=()
-options=()
-#install=
-source=()
-md5sums=()
-noextract=()
+arch=(any)
+url="https://github.com/fsquillace/junest"
+license=(GPL)
+depends=(fakeroot fakechroot)
+provides=(sudo)
+conflicts=(sudo)
+source=(sudo)
+sha256sums=('78590602ba6e4a03d75afa7dfcc9f2c32143aac56056b7663fb485c13660f303')
 
 package() {
-    install -d -m 755 "${pkgdir}/usr/bin/"
-    cat <<EOF > "${pkgdir}/usr/bin/sudo"
-#!/bin/bash
-for opt in "\$@"
-do
-    case "\$1" in
-        --) shift ; break ;;
-        -*) shift ;;
-        *) break ;;
-    esac
-done
-
-[[ -z "\${@}" ]] || fakechroot fakeroot "\${@}"
-EOF
-
-    chmod 755 "${pkgdir}/usr/bin/sudo"
+  install -D sudo "${pkgdir}"/usr/bin/sudo
 }
 
 # vim:set ts=2 sw=2 et:

--- a/pkgs/sudo-fake/sudo
+++ b/pkgs/sudo-fake/sudo
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+for opt in "$@"
+do
+	case "$1" in
+		--) shift ; break ;;
+		-*) shift ;;
+		*) break ;;
+	esac
+done
+
+[[ -z "${@}" ]] || fakechroot fakeroot "${@}"
+


### PR DESCRIPTION
This tidies the `fake-sudo` PKGBUILD, removing unnecessary empty array declarations and updating the wrapper script shebang.