### PR TITLE
🐧 Initial commit of bin-wrapper

### DIFF
--- a/pkgs/bin-wrapper/PKGBUILD
+++ b/pkgs/bin-wrapper/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Jonathon Fernyhough <jonathon at+manjarodotorg>
+
+pkgname=bin-wrapper
+pkgver=0.0.1
+pkgrel=1
+pkgdesc="Automatically wrap JuNest executables for use in outer system's PATH"
+arch=(any)
+url="https://github.com/fsquillace/junest"
+license=(GPL)
+source=(create-wrapper
+        delete-wrapper
+        junest-wrapper
+        create-wrapper.hook
+        delete-wrapper.hook)
+sha256sums=('0b9d2fe31fee1d514295399fade8ae178d8c6fcc918e81286084337cfd900663'
+            '46ecdd2404e6bf8310e02fcfd8e0690405d52ce07b82dff2f0c9cbad31e40f67'
+            'f27807aae86daec311d601b1b954be1ee274232f9416963449514a2b00b34b83'
+            'ed6ce2ab02368427aab12d3aa36e2b1741cca526bd4caf55a90687bb117ea358'
+            '3a08a9c2889d9cb97fc2a53a5e045372477fde7261b0cbda1c332cd0c4ec1b1f')
+
+package() {
+	install -Dm644 -t "$pkgdir"/usr/lib/libalpm/hooks     *.hook
+	install -Dm644 -t "$pkgdir"/usr/share/doc/bin-wrapper README
+	install -D     -t "$pkgdir"/wrappers                  *-wrapper
+}

--- a/pkgs/bin-wrapper/README
+++ b/pkgs/bin-wrapper/README
@@ -1,0 +1,14 @@
+This set of scripts and hooks will trigger pacman to create a wrapper script
+for any executable installed under /usr/bin/. The wrapper will be removed when
+the executable is removed.
+
+This will allow you to place $JUNEST_HOME/wrappers in your $PATH and use any
+JuNest-installed application transparently, including the use of a desktop
+launcher.
+
+The wrapper script targets the default (ns) JuNest back-end and will bind to
+any locations specified by a $JUNEST_BINDS environment variable, e.g.:
+
+export JUNEST_BINDS="--bind /media /media"
+
+You will have to export $JUNEST_HOME as normal. junest must be on your $PATH.

--- a/pkgs/bin-wrapper/create-wrapper
+++ b/pkgs/bin-wrapper/create-wrapper
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+while read input; do
+	[[ -n "$input" ]] && /usr/bin/ln -sf junest-wrapper /wrappers/$(/usr/bin/basename "$input")
+done

--- a/pkgs/bin-wrapper/create-wrapper.hook
+++ b/pkgs/bin-wrapper/create-wrapper.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = usr/bin/?*
+[Action]
+Description = Create/Update JuNest wrapper
+When = PostTransaction
+Exec = /wrappers/create-wrapper
+NeedsTargets

--- a/pkgs/bin-wrapper/delete-wrapper
+++ b/pkgs/bin-wrapper/delete-wrapper
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+while read input; do
+	[[ -n "$input" ]] && /usr/bin/rm -f /wrappers/$(/usr/bin/basename "$input")
+done

--- a/pkgs/bin-wrapper/delete-wrapper.hook
+++ b/pkgs/bin-wrapper/delete-wrapper.hook
@@ -1,0 +1,9 @@
+[Trigger]
+Operation = Remove
+Type = Path
+Target = usr/bin/?*
+[Action]
+Description = Remove JuNest wrapper
+When = PostTransaction
+Exec = /wrappers/delete-wrapper
+NeedsTargets

--- a/pkgs/bin-wrapper/junest-wrapper
+++ b/pkgs/bin-wrapper/junest-wrapper
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec junest ns -n -b "$JUNEST_BINDS" -- /usr/bin/$(/usr/bin/basename $0) $@


### PR DESCRIPTION
This is an experimental hook-wrapper combo which allows for automatic wrapping of JuNest applications ready for use in the outer system's `$PATH`. It's essentially an extension of the [Command Not Found](https://github.com/fsquillace/junest/wiki/Automatic-fallback-to-Junest-for-not-found-commands-in-the-native-Linux-system) fallback but allows users to explicitly use JuNest packages "natively".

Having this in place should also allow for future enhancements around application launchers (.desktop files), i.e. when the `executable` is in `$PATH` then you can use just `Exec=executable`