### PR TITLE
Fix installation guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ section below.
 ## Installation from git repository ##
 Just clone the JuNest repo somewhere (for example in ~/.local/share/junest):
 
-    git clone git://github.com/fsquillace/junest ~/.local/share/junest
+    git clone https://github.com/fsquillace/junest.git ~/.local/share/junest
     export PATH=~/.local/share/junest/bin:$PATH
 
 ### Installation using AUR (Arch Linux only) ###


### PR DESCRIPTION
(Previously #273)

Current installation command fails on Ubuntu 21.10 because the unauthenticated git protocol on port 9418 is no longer supported:

```sh
$ git clone https://github.com/fsquillace/junest.git ~/.local/share/junest
Cloning into '/home/ayaka/.local/share/junest'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Changing to https fixes this issue.