### PR TITLE
Add Nix/NixOS support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).defaultNix 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1639566195,
+        "narHash": "sha256-ZnTBGSV6bTwopdDibmsBaAkedmTZC/rOgwQzOGcOD+s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c52ea8c9216a0d5b7a7b4d74a9d2e858b06df5c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
                        mv bin/junest $out/bin
                        mv lib/* $out/lib
                        chmod +w $out/bin/junest
-                       chmod +w -R $out/lib/*
                        runHook postInstall
                        '';
                        

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "The lightweight Arch Linux based distribution that runs without root access upon any Linux distros."; 
+  
+      inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+      inputs.flake-utils.url = "github:numtide/flake-utils";
+      inputs.flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+      
+      outputs = { self, nixpkgs, flake-utils, flake-compat }:
+        let
+           systems = [ "x86_64-linux" "aarch64-linux" ];
+        in
+        flake-utils.lib.eachSystem systems (system:
+            let 
+               pkgs = nixpkgs.legacyPackages.${system};
+
+               junest = with pkgs; stdenvNoCC.mkDerivation rec {
+                   pname = "junest";
+                   version = "7.3.9";
+                   src = ./.;
+                   
+                   doBuild= false;
+
+                   nativeBuildInputs = [ makeWrapper ];
+
+                   installPhase = ''
+                       mkdir -p $out/{bin,lib}
+                       mv bin/junest $out/bin
+                       mv lib/* $out/lib
+                       chmod +w $out/bin/junest
+                       chmod +w -R $out/lib/*
+                       runHook postInstall
+                       '';
+                       
+                   postInstall = ''
+                       substituteInPlace $out/lib/core/common.sh \
+                             --replace "PATH=/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:\''${HOME}/.local/bin" " "
+                      '';
+                      
+                    postFixup = ''
+                        wrapProgram $out/bin/junest \
+                            --prefix PATH ":" "${coreutils}/bin" \
+                            --prefix PATH ":" "${getent}/bin/getent" \
+                            --prefix PATH ":" "${gzip}/bin/zgrep" \
+                            --prefix PATH ":" "${gnutar}/bin/tar" \
+                            --prefix PATH ":" "${wget}/bin/wget" \
+                            --prefix PATH ":" "${curl}/bin/curl"
+                       '';
+               };
+            in
+               rec {
+                   packages.junest = junest;
+                   defaultPackage = self.packages.${system}.junest;
+                   });
+ }
+        
+  
+  


### PR DESCRIPTION
## Features
This pull request enables Nix and NixOS support via nix flakes

- Added a flake.nix for flake enabled systems.
- Added a default.nix for non-flake systems.

## Important Notes

- Testing must be done to ensure there are no breaking issues with junest after nix install it. 

- Issues must be fixed before merging this pull request.
