### PR TITLE
Fix quoting in wrapper script

### DIFF
--- a/lib/core/wrappers.sh
+++ b/lib/core/wrappers.sh
@@ -1,9 +1,9 @@
 
 
 function create_wrappers() {
-    mkdir -p ${JUNEST_HOME}/usr/bin_wrappers
+    mkdir -p "${JUNEST_HOME}/usr/bin_wrappers"
 
-    cd ${JUNEST_HOME}/usr/bin
+    cd "${JUNEST_HOME}/usr/bin" || return 1
     for file in *
     do
         [[ -x $file ]] || continue
@@ -14,21 +14,21 @@ function create_wrappers() {
         # Arguments inside a variable (i.e. `JUNEST_ARGS`) separated by quotes
         # are not recognized normally unless using `eval`. More info here:
         # https://github.com/fsquillace/junest/issues/262
-        cat <<EOF > ${JUNEST_HOME}/usr/bin_wrappers/${file}
+        cat <<EOF > "${JUNEST_HOME}/usr/bin_wrappers/${file}"
 #!/usr/bin/env bash
 
 JUNEST_ARGS=\${JUNEST_ARGS:-ns --fakeroot}
 
-eval junest \${JUNEST_ARGS} -- ${file} "\$@"
+eval junest "\${JUNEST_ARGS}" -- ${file} "\$(printf "%q" "\$@")"
 EOF
-        chmod +x ${JUNEST_HOME}/usr/bin_wrappers/${file}
+        chmod +x "${JUNEST_HOME}/usr/bin_wrappers/${file}"
     done
 
     # Remove wrappers no longer needed
-    cd ${JUNEST_HOME}/usr/bin_wrappers
+    cd "${JUNEST_HOME}/usr/bin_wrappers" || return 1
     for file in *
     do
-        [[ -e ${JUNEST_HOME}/usr/bin/$file ]] || rm -f $file
+        [[ -e ${JUNEST_HOME}/usr/bin/$file ]] || rm -f "$file"
     done
 
 }


### PR DESCRIPTION
The 'eval' introduced in #262 unfortunately breaks command
invocations were a parameter contains spaces, such as

```
rg "my pattern with spaces"
```

as it would be called as `rg my pattern with
spaces`. This can be fixed using the `"${@@Q}"` operator in bash, see
https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

At least the above invocation then works correctly! This PR also fixes some other shell check warnings by using quoting of variables (just in case somebody has a space in `$HOME`)