### PR TITLE
Update PATH variable without duplicating entries

### DIFF
--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -25,9 +25,19 @@ UNPRIVILEGED_USERNS_DISABLED=109
 JUNEST_HOME=${JUNEST_HOME:-~/.${CMD}}
 JUNEST_TEMPDIR=${JUNEST_TEMPDIR:-/tmp}
 
-# The update of the variable PATH ensures that the executables are
-# found on different locations
-PATH=/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:${HOME}/.local/bin:"$PATH"
+# The following function updates the PATH variable to ensure that
+# required executables are found in their default locations
+# without cluttering the user's PATH with duplicates.
+function _path_prepend(){
+    PATH=:$PATH
+    PATH=$1${PATH//:$1:/:}
+}
+_path_prepend ${HOME}/.local/bin
+_path_prepend /sbin
+_path_prepend /usr/sbin
+_path_prepend /usr/local/bin
+_path_prepend /bin
+_path_prepend /usr/bin
 
 # The executable uname is essential in order to get the architecture
 # of the host system, so a fallback mechanism cannot be used for it.

--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -32,7 +32,7 @@ function _path_prepend(){
     PATH=:$PATH
     PATH=$1${PATH//:$1:/:}
 }
-_path_prepend ${HOME}/.local/bin
+_path_prepend "${HOME}"/.local/bin
 _path_prepend /sbin
 _path_prepend /usr/sbin
 _path_prepend /usr/local/bin


### PR DESCRIPTION
Since common.sh is called every time that JuNest is run, the current implementation ends up cluttering the PATH variable with duplicate entries, making it far more difficult for end users to manage their PATH variables themselves. This commit solves that problem by prepending necessary paths with a function that deletes them if they are already present, effectively promoting them rather than duplicating them.