### PR TITLE
feat: bump default shell to bash instead of sh

### DIFF
--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -67,7 +67,7 @@ ORIGIN_WD=$(pwd)
 # different locations in the host OS.
 
 # List of executables that are run inside JuNest:
-DEFAULT_SH=("/bin/sh" "--login")
+DEFAULT_SH=("/bin/bash" "--login")
 
 # List of executables that are run in the host OS:
 BWRAP="${JUNEST_HOME}/usr/bin/bwrap"


### PR DESCRIPTION
Given this argument uses the guest (archlinux) binary, it makes sense to use bash instead of sh as default. This resolves issues such as https://github.com/junegunn/fzf/issues/3063

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>