### PR TITLE
Fix PATH variable being empty in trapped function

### DIFF
--- a/lib/core/namespace.sh
+++ b/lib/core/namespace.sh
@@ -103,6 +103,7 @@ function run_env_as_bwrap_fakeroot(){
 
     # Fix PATH to /usr/bin to make sudo working and avoid polluting with host related bin paths
     # shellcheck disable=SC2086
+    local JUNEST_ORIGINAL_PATH="$PATH"
     PATH="/usr/bin" BWRAP="${backend_command}" JUNEST_ENV=1 bwrap_cmd $COMMON_BWRAP_OPTION --cap-add ALL --uid 0 --gid 0 $backend_args sudo "${DEFAULT_SH[@]}" "${args[@]}"
 }
 
@@ -153,6 +154,7 @@ function run_env_as_bwrap_user() {
 
     # Resets PATH to avoid polluting with host related bin paths
     # shellcheck disable=SC2086
+    local JUNEST_ORIGINAL_PATH="$PATH"
     PATH='' BWRAP="${backend_command}" JUNEST_ENV=1 bwrap_cmd $COMMON_BWRAP_OPTION $backend_args "${DEFAULT_SH[@]}" "${args[@]}"
 }
 

--- a/lib/core/proot.sh
+++ b/lib/core/proot.sh
@@ -18,6 +18,7 @@ function _run_env_with_proot(){
     [[ "$1" != "" ]] && args=("-c" "$(insert_quotes_on_spaces "${@}")")
 
     # Resets PATH to avoid polluting with host related bin paths
+    local JUNEST_ORIGINAL_PATH="$PATH"
     PATH='' PROOT="${backend_command}" JUNEST_ENV=1 proot_cmd "${backend_args}" "${DEFAULT_SH[@]}" "${args[@]}"
 }
 

--- a/lib/core/wrappers.sh
+++ b/lib/core/wrappers.sh
@@ -19,6 +19,7 @@
 #   None
 #######################################
 function create_wrappers() {
+    local PATH="${JUNEST_ORIGINAL_PATH:-"$PATH"}"
     local force=${1:-false}
     local bin_path=${2:-/usr/bin}
     bin_path=${bin_path%/}


### PR DESCRIPTION
Commit 9b00c5c4c51c513b09ae32b97a0fbd8ca8590d45 introduced reducing `$PATH` when executing junest env. However, when the trap function is invoked due to failed command, the `$PATH` will becomes empty within the context of create wrapper.

Here are what happens before the PR when the trapped `create_wrappers` function is invoked under a failed status

```sh
$ ./bin/junest -- true
$ echo $?
0
```

```sh
$ ./bin/junest -- false
/home/soraxas/junest/lib/core/wrappers.sh: line 23: mkdir: No such file or directory
$ echo $?
127
```